### PR TITLE
Pin to Blinka version 7.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-Adafruit-Blinka
+Adafruit-Blinka>=7.0.0
 adafruit-circuitpython-busdevice
 adafruit-circuitpython-register
 adafruit-circuitpython-pca9685

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
     install_requires=[
-        "Adafruit-Blinka",
+        "Adafruit-Blinka>=7.0.0",
         "adafruit-circuitpython-busdevice",
         "adafruit-circuitpython-register",
         "adafruit-circuitpython-pca9685",


### PR DESCRIPTION
Fixes #38 by requiring Blinka to be 7.0.0 or higher (where Python 3.7+ was enforced).